### PR TITLE
ci: removed load data workflow cron trigger

### DIFF
--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -3,9 +3,9 @@ name: Load data
 
 on:
   workflow_dispatch:
-  schedule:
-    # run every day at 02:00
-    - cron: '0 2 * * *'
+#  schedule:
+#    # run every day at 02:00
+#    - cron: '0 2 * * *'
 
 jobs:
   load:


### PR DESCRIPTION
@ilan-pinto @bennypowers

FYI - I don't know if this is still being used, but I assume the RedHat-Israel org got too big for my token last week, and this started failing.
So I'm blocking the recurring trigger until we have time to figure this out if anyone is still using it.
For the record, this repository hosts the summary of RH IL associates' contributions; it's used in the RH IL site.

![image](https://github.com/user-attachments/assets/5dfe16f3-e2f9-46ac-a2d1-aa2b82d1b2c4)
